### PR TITLE
efficient-loading for 4D data

### DIFF
--- a/bin/freeroi
+++ b/bin/freeroi
@@ -1,4 +1,4 @@
-#! /bin/env python
+#! /usr/bin/env python
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Main application for PyBP GUI.

--- a/froi/gui/base/bpdataset.py
+++ b/froi/gui/base/bpdataset.py
@@ -8,7 +8,6 @@ import re
 import os
 import nibabel as nib
 import numpy as np
-from sets import Set
 
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *


### PR DESCRIPTION
1. For 4D nifti image, each volume is loaded in the memory as it is called by user.
2. For the convenience of Mac OSX users, the `env` is altered.