### PR TITLE
fix bug in datamodel

### DIFF
--- a/froi/gui/component/datamodel.py
+++ b/froi/gui/component/datamodel.py
@@ -308,7 +308,8 @@ class VolumeListModel(QAbstractListModel):
 
         """
         if data is None:
-            new_data = np.zeros(self._data[0].get_data_shape()[0:3], dtype=np.int_)
+            new_data = np.zeros(self._data[0].get_data_shape()[0:3],
+                                dtype=np.uint8)
         else:
             new_data = data
         new_header = self._data[0].get_header().copy()


### PR DESCRIPTION
While initializing an empty new image, the default datatype is modified as uint8 for compatiblity with fslview.