### PR TITLE
update setup for new version pyqt4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nose
 numpy
 scikits-image
 scipy
+pyqt==4.10


### PR DESCRIPTION
In new version PyQt4 (>=4.10) package, some APIs have been changed, and cause unexpected crash while compiling qimageview.so. Thus I update the installation script to fix the problem temporarily.