### PR TITLE
Remove unnecessary signal-slot connections. By the way, fix a corresp…

### DIFF
--- a/froi/widgets/surfacetreewidget.py
+++ b/froi/widgets/surfacetreewidget.py
@@ -161,15 +161,6 @@ class SurfaceTreeView(QWidget):
         # self._tree_view.selectionModel().currentChanged.connect(
         #        self.current_changed)
 
-        # When dataset changed, refresh display.
-        self._model.dataChanged.connect(self._disp_current_para)
-
-        # When add new item, refresh display.
-        self._model.rowsInserted.connect(self._disp_current_para)
-
-        # When remove new item, refresh display.
-        self._model.rowsRemoved.connect(self._disp_current_para)
-
         # When layout changed, refresh display.
         self._model.layoutChanged.connect(self._disp_current_para)
 


### PR DESCRIPTION
…onding bug
之前，在导入一个新的overlay的时候  会把当前选中的overlay的colormap改成结构像中保存的colormap。
昨天我发现这个bug的原因是，在insert或是delete一个overlay的时候，会发射rowsInserted和rowsRemoved两个信号，这两个信号都被连接到了_disp_current_para这个槽函数。而这个槽函数其中有一段是用传递进来的QModelIndex（如果是-1 则自动获取当前item对应的Index）中的colormap重设当前item的colormap，由于这两个信号会默认传递结构像对应的QModelIndex（所以这一次的display显示的是结构像的可视化信息），所以当前item的colormap会被更改成结构像的colormap，由于这个变化触发了model里的setData函数使其发出dataChanged这个信号，这个信号也被连接到了_disp_current_para这个槽函数，于是有一次的触发这个槽函数进行display（这一次传进来的是当前item对应的Index），结果最终是正确显示出了当前overlay的可视化信息，只是colormap被改变了。
解决办法就是，我去除了dataChanged、rowsInserted和rowsRemoved这三个信号和_disp_current_para的连接，因为，第一，dataChanged是由用户改变可视化参数时触发的，不需要调用_disp_current_para也可以看见改变后的参数。第二，rowsInserted是由插入新的item触发的，当插入新的item时当前选中的item并没有变，所以不需要更新可视化参数。第三，rowsRemoved是由删除一个item触发的，这会引起layoutChanged或是currentChanged（本以为是这个原因，但是发现我把这两个连接注释掉以后，remove item这个操作照样能更新参数）的发射，然后由其连接到_disp_current_para来更新overlay的可视化参数。