### PR TITLE
BF: 1. transition_level assessment: return 0 now when denominator is …

### DIFF
--- a/froi/algorithm/meshtool.py
+++ b/froi/algorithm/meshtool.py
@@ -484,6 +484,10 @@ def get_n_ring_neighbor(faces, n=1, ordinal=False, mask=None):
         each element is a set which includes neighbors of corresponding vertex
     """
     n_vtx = np.max(faces) + 1  # get the number of vertices
+    if mask is not None and np.nonzero(mask)[0].shape[0] == n_vtx:
+        # In this case, the mask covers all vertices and is equal to have no mask (None).
+        # So the program reset it as a None that it will save the computational cost.
+        mask = None
 
     # find 1_ring neighbors' id for each vertex
     coo_w = mesh_edges(faces)
@@ -960,7 +964,7 @@ class LabelAssessment(object):
                     couple_signal = np.r_[np.atleast_2d(data[vtx_i]), np.atleast_2d(data[vtx_o])]
                     sum_tmp += pdist(couple_signal)[0]
                     count += 1
-        return sum_tmp / float(count)
+        return sum_tmp / float(count) if count else 0
 
 
 if __name__ == '__main__':

--- a/froi/widgets/surfaceRGdialog.py
+++ b/froi/widgets/surfaceRGdialog.py
@@ -382,9 +382,9 @@ class SurfaceRGDialog(QtGui.QDialog):
         elif self.rg_type == 'crg':
 
             if depth == 1:
-                edge_list = get_n_ring_neighbor(geometry.faces, n=self.n_ring)
-                for cut_vtx in self.cut_line:
-                    edge_list[cut_vtx] = set()
+                mask = np.ones(np.max(geometry.faces) + 1)
+                mask[self.cut_line] = 0
+                edge_list = get_n_ring_neighbor(geometry.faces, n=self.n_ring, mask=mask)
                 rg_result = rg.connectivity_grow(self.seeds_id, edge_list)
 
             elif depth == 2:
@@ -397,14 +397,11 @@ class SurfaceRGDialog(QtGui.QDialog):
 
                 self.crg_results = list()
                 for thr in self.thresholds:
-                    if thr == "None":
-                        edge_list = get_n_ring_neighbor(geometry.faces, n=self.n_ring)
-                    else:
-                        mask = scalar_data > float(thr)
-                        edge_list = get_n_ring_neighbor(geometry.faces, n=self.n_ring, mask=mask)
-
-                    for cut_vtx in self.cut_line:
-                        edge_list[cut_vtx] = set()
+                    mask = np.ones(np.max(geometry.faces) + 1)
+                    if thr != "None":
+                        mask[scalar_data <= float(thr)] = 0
+                    mask[self.cut_line] = 0
+                    edge_list = get_n_ring_neighbor(geometry.faces, n=self.n_ring, mask=mask)
 
                     self.crg_results.append(rg.connectivity_grow(self.seeds_id, edge_list))
 


### PR DESCRIPTION
…0; 2. Fix bug that crg will merge vertices on the cut_line, which should be excluded.